### PR TITLE
Allow a different initial interval in Writer

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -67,7 +67,7 @@ function Writer (metaint, opts) {
 
   this.metaint = +metaint;
 
-  initialInt = (opts && isFinite(opts.initialMetaInt)) ? +opts.initialMetaInt : this.metaint
+  initialInt = (opts && opts.initialMetaInt && isFinite(opts.initialMetaInt)) ? +opts.initialMetaInt : this.metaint
 
   this._queue = [];
 


### PR DESCRIPTION
For [StreamMachine](https://github.com/StreamMachine/StreamMachine), I'm working on being able to hand off all connections to a new process to allow seamless restarts.  To do that with an Icecast writer, I need a way to tell the new process that it should write less than a full chunk of data before the first meta injection.

I'm grabbing `_parserBytesLeft` from the original icecast writer, and then passing that in to the new one as `initialMetaInt`.
