### PR TITLE
Added useragent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ icy.get(url, function (res) {
 });
 ```
 
+You are also able to add custom headers to your request:
+```javascript
+var url = require('url');
+
+// URL to a known ICY stream
+var opts = url.parse('http://yourstreamurl.tld/');
+
+// add custom headers
+opts.headers = { 'User-Agent': 'Your awesome useragent' };
+
+// connect to the remote stream
+icy.get(opts, callback);
+```
+
 
 API
 ---


### PR DESCRIPTION
The `options` parameter of `Client` now takes an array with the following entries:

 - `url`: URL of ICY-stream
 - `useragent`: useragent to use for connection

Example: 
```javascript
var options = {
  url: 'http://yourstreamurl.tld/',
  userAgent: 'Your awesome useragent'
};

icy.get(options, ...
```

As said above, the use of an array is optional, so you are still able to use a string as your `options` parameter.